### PR TITLE
Port to GitLab API v4 / python-gitlab>=1.3.0.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ Command-line script to migrate Gitlab issues to Kanboard.
 
 == Requirements
 
-- Gitlab >= 8.13.8
+- Gitlab >= 9.0.0
 - Kanboard >= 1.0.42
 
 [NOTE]

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -1,3 +1,3 @@
 envparse==0.2.0
 kanboard==1.0.1
-python-gitlab==0.20
+python-gitlab>=1.3.0


### PR DESCRIPTION
(Tested with python-gitlab 1.3.0 and 3.9.0.) GitLab no longer supports API v3 (since 11.0), so the port to API v4 is required to make this work at all with any recent version of GitLab (i.e., GitLab >= 11.0).

requirements/_base.txt: Bump python-gitlab requirement to >=1.3.0.

kanboard_gitlab/importer.py: Import requests globally, not from gitlab. Port to GitLab API v4: groups.search is gone, use groups.list(search=…) instead; a GroupProject must be explicitly converted to a full Project; a user is now a dict, so use ['username'] instead of .username on users.

README.adoc: Bump minimum required GitLab version to 9.0.0, where API v4 was introduced.